### PR TITLE
Remove Types

### DIFF
--- a/src/net/gosha/atproto/types.clj
+++ b/src/net/gosha/atproto/types.clj
@@ -1,3 +1,0 @@
-(ns net.gosha.atproto.types)
-
-(defrecord RepoInfo [did name])


### PR DESCRIPTION
This is more of a stylistic suggestion, so feel free to just close if you're confident in your approach.

I recommend against the use of records unless you need one of the specific things they provide (i.e. Java interop or type-based polymorphism.) They provide no type safety or validation like a class does in a statically typed language.

The most idiomatic Clojure approach is to have all internal data be just primitives, maps, seqs and sets.

If you know data needs to conform to a particular structure you can use spec, but even that is strongly optional. If you're going to use specs, I usually recommend adding them *after* you've got the code stable. If you write your specs first, you lose the benefits of dynamic typing and quick iteration as you code, since you have to keep going back and changing the specs every time you change your mind about structure, which can easily double up the amount of work.