### PR TITLE
Firehose (/w analytics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pom.xml.asc
 /.cpcache
 
 sample-messages.edn
+/samples

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom.xml.asc
 /.nrepl-port
 /.prepl-port
 /.cpcache
+
+sample-messages.edn

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        org.clojure/data.json {:mvn/version "2.5.0"}
-        http-kit/http-kit {:mvn/version "2.8.0"}
-        metosin/reitit {:mvn/version "0.7.2"}}}
+ :deps {org.clojure/clojure   {:mvn/version "1.12.0"}
+        org.clojure/data.json {:mvn/version "2.5.1"}
+        http-kit/http-kit     {:mvn/version "2.8.0"}
+        metosin/reitit        {:mvn/version "0.7.2"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,11 +2,11 @@
 
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/core.async    {:mvn/version "1.6.681"}
-         org.clojure/data.json     {:mvn/version "2.5.1"}
          org.clojure/tools.logging {:mvn/version "1.3.0"}
 
-         http-kit/http-kit {:mvn/version "2.8.0"}
-         metosin/reitit    {:mvn/version "0.7.2"}
-         mvxcvi/clj-cbor   {:mvn/version "1.1.1"}
+         com.cnuernber/charred {:mvn/version "1.034"}
+         http-kit/http-kit     {:mvn/version "2.8.0"}
+         metosin/reitit        {:mvn/version "0.7.2"}
+         mvxcvi/clj-cbor       {:mvn/version "1.1.1"}
          org.java-websocket/Java-WebSocket {:mvn/version "1.5.4"}
          org.slf4j/slf4j-simple {:mvn/version "2.0.16"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,12 @@
 {:paths ["src"]
- :deps {org.clojure/clojure   {:mvn/version "1.12.0"}
-        org.clojure/data.json {:mvn/version "2.5.1"}
-        http-kit/http-kit     {:mvn/version "2.8.0"}
-        metosin/reitit        {:mvn/version "0.7.2"}}}
+
+ :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
+         org.clojure/core.async    {:mvn/version "1.6.681"}
+         org.clojure/data.json     {:mvn/version "2.5.1"}
+         org.clojure/tools.logging {:mvn/version "1.3.0"}
+
+         http-kit/http-kit {:mvn/version "2.8.0"}
+         metosin/reitit    {:mvn/version "0.7.2"}
+         mvxcvi/clj-cbor   {:mvn/version "1.1.1"}
+         org.java-websocket/Java-WebSocket {:mvn/version "1.5.4"}
+         org.slf4j/slf4j-simple {:mvn/version "2.0.16"}}}

--- a/resources/dev-config.edn
+++ b/resources/dev-config.edn
@@ -1,0 +1,2 @@
+{:username "chaselambert.dev"
+ :password #env BSKY_APP_PASSWORD}

--- a/src/net/gosha/atproto/client.clj
+++ b/src/net/gosha/atproto/client.clj
@@ -1,41 +1,41 @@
 (ns net.gosha.atproto.client
-  (:require [org.httpkit.client :as http]
-            [clojure.data.json :as json]
-            [clojure.pprint :refer [pprint]]
+  (:require [org.httpkit.client     :as http]
+            [clojure.data.json      :as json]
+            [clojure.pprint         :refer [pprint]]
             [net.gosha.atproto.core :as core]))
 
 (defn request
   "Make an HTTP request to the atproto API.
-  - `method`: HTTP method (:get, :post, etc.)
-  - `endpoint`: API endpoint (relative to `:base-url`)
-  - `body`: Request body (optional)
-  - `headers`: Additional headers (optional)
-  - `retries`: Number of retries for transient failures"
+  - `method`   : HTTP method (:get, :post, etc.)
+  - `endpoint` : API endpoint (relative to `:base-url`)
+  - `body`     : Request body (optional)
+  - `headers`  : Additional headers (optional)
+  - `retries`  : Number of retries for transient failures"
   [method endpoint & [{:keys [body headers retries] :or {retries 3}}]]
   (let [{:keys [base-url auth-token]} @core/config]
     (when-not base-url
       (throw (ex-info "SDK not initialised: missing base-url" {})))
     (let [url (str base-url endpoint)
-          options {:method method
-                   :url url
+          options {:method  method
+                   :url     url
                    :headers (merge {"Authorization" (str "Bearer " auth-token)
                                     "Content-Type" "application/json"}
                                    headers)
-                   :body (when body (json/write-str body))}]
+                   :body    (when body (json/write-str body))}]
       (loop [attempt 0]
         (let [response (try
                          {:success true
-                          :result @(http/request options)}
+                          :result  @(http/request options)}
                          (catch Exception e
                            {:success false
-                            :error e}))]
+                            :error   e}))]
           (if (:success response)
             (let [result (:result response)]
               (if (<= 200 (:status result) 299)
                 (update result :body json/read-str :key-fn keyword)
                 (throw (ex-info "API request failed"
                                 {:status (:status result)
-                                 :body (:body result)}))))
+                                 :body   (:body result)}))))
             (if (>= attempt retries)
               (throw (:error response))
               (do
@@ -59,7 +59,7 @@
   []
   (let [endpoint "/xrpc/com.atproto.server.createSession"
         response (post-req endpoint {:identifier (:username @core/config)
-                                 :password (:app-password @core/config)}
+                                     :password   (:app-password @core/config)}
                        {:base-url (:base-url @core/config)})
         token (get-in response [:body :accessJwt])]
     (swap! core/config assoc :auth-token token)))

--- a/src/net/gosha/atproto/core.clj
+++ b/src/net/gosha/atproto/core.clj
@@ -2,12 +2,12 @@
   (:require [clojure.spec.alpha :as s]))
 
 ;; Spec for SDK configuration
-(s/def ::base-url string?)
-(s/def ::auth-token (s/nilable string?))
+(s/def ::base-url     string?)
+(s/def ::auth-token   (s/nilable string?))
 (s/def ::app-password (s/nilable string?))
-(s/def ::username (s/nilable string?))
-(s/def ::config (s/keys :req-un [::base-url]
-                        :opt-un [::auth-token ::app-password ::username]))
+(s/def ::username     (s/nilable string?))
+(s/def ::config       (s/keys :req-un [::base-url]
+                              :opt-un [::auth-token ::app-password ::username]))
 
 (defonce config (atom {}))
 
@@ -26,13 +26,13 @@
 
 (comment
   ; Initialise configuration
-  (init {:base-url "https://bsky.social"
-         :username "someuser.bsky.social"
+  (init {:base-url     "https://bsky.social"
+         :username     "someuser.bsky.social"
          :app-password "some-app-password"})
   ; Exchange app password for auth token
   (net.gosha.atproto.client/authenticate!)
   ; Make API requests
-  (net.gosha.atproto.client/get-req "/xrpc/com.atproto.server.getSession")
+  (net.gosha.atproto.client/get-req "/xrpc/com.atproto.server.getSession"))
   ; ???
   ; Profit
-  )
+  

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -2,95 +2,82 @@
   (:require
    [clojure.core.async    :as async]
    [clojure.tools.logging :as log]
-   [clj-cbor.core         :as cbor])
+   [clojure.data.json     :as json])
   (:import
-   [java.io ByteArrayInputStream]
-   [java.nio ByteBuffer]
    [java.net URI]
-   [org.java_websocket.client WebSocketClient]
-   [org.java_websocket.handshake ServerHandshake]))
+   [org.java_websocket.client WebSocketClient]))
 
-(defn read-varint
-  "Read a variable-length integer from the input stream"
-  [^ByteArrayInputStream in]
-  (loop [shift 0
-         result 0]
-    (let [b (.read in)]
-      (if (neg? b)
-        (throw (ex-info "EOF while reading varint" {})))
-      (let [val    (bit-and b 0x7F)
-            result (bit-or result (bit-shift-left val shift))]
-        (if (zero? (bit-and b 0x80))
-          result
-          (recur (+ shift 7) result))))))
-
-(defn decode-frame
-  "Decode a single frame from binary data"
-  [^ByteBuffer buffer]
-  (try 
-    (let [bytes (byte-array (.remaining buffer))]
-      (.get buffer bytes)
-      (with-open [in (ByteArrayInputStream. bytes)]
-        (let [frame-len   (read-varint in)
-              frame-bytes (byte-array frame-len)]
-          (.read in frame-bytes 0 frame-len)
-          (let [decoded (cbor/decode frame-bytes)]
-            {:header {:t  (get decoded "t")}
-                     :op (get decoded "op")
-             :body   decoded}))))
+(defn parse-firehose-message
+  "Parse a firehose message into a structured format"
+  [message]
+  (try
+    (let [data (json/read-str message :key-fn keyword)]
+      (case (:kind data)
+        "commit" 
+        {:type       :commit
+         :did        (:did data)
+         :timestamp  (:time_us data)
+         :rev        (get-in data [:commit :rev])
+         :operation  (get-in data [:commit :operation])
+         :collection (get-in data [:commit :collection])
+         :record     (get-in data [:commit :record])
+         :raw        data}
+        
+        {:type :unknown
+         :data data}))
     (catch Exception e
-      (log/error "Frame decode error:" (.getMessage e))
+      (log/error "Parse error:" (.getMessage e))
       nil)))
 
 (defn create-websocket-client
-  [{:keys [uri output-ch]}]
-  (proxy [WebSocketClient] [(URI. uri)]
-    (onOpen [^ServerHandshake handshake]
-      (log/info "Connected to firehose"))
-    
-    (onClose [code reason remote]
-      (log/info "Disconnected from firehose:" reason))
-    
-    (onMessage [^ByteBuffer buffer]
-      (when-let [frame (decode-frame buffer)]
-        (async/>!! output-ch frame)))
-    
-    (onError [^Exception ex]
-      (log/error "WebSocket error:" (.getMessage ex)))))
+  [uri output-ch]
+  (doto 
+    (proxy [WebSocketClient] [(URI. (str uri "?wantedCollections=app.bsky.feed.post"))]
+      (onOpen [_]
+        (log/info "Connected to jetstream"))
+      
+      (onClose [code reason remote]
+        (log/info "Disconnected from jetstream:" reason))
+      
+      (onMessage [message]
+        (when-let [parsed (parse-firehose-message message)]
+          (async/>!! output-ch parsed)))
+      
+      (onError [^Exception ex]
+        (log/error "WebSocket error:" (.getMessage ex))))
+    (.setConnectionLostTimeout 60)))
 
 (defn connect-firehose
   "Connect to ATProto firehose and return a channel of events"
   [& {:keys [buffer-size service]
       :or   {buffer-size 1024
-             service     "wss://bsky.network"}}]
+             service     "wss://jetstream2.us-east.bsky.network"}}]
   (let [output-ch (async/chan buffer-size)
-        uri       (str service "/xrpc/com.atproto.sync.subscribeRepos")
-        client    (create-websocket-client
-                   {:uri       uri
-                    :output-ch output-ch})]
+        uri       (str service "/subscribe")
+        client    (create-websocket-client uri output-ch)]
     
     (.connect client)
     
     {:client client
      :events output-ch}))
 
-(defn disconnect 
+(defn disconnect
   [{:keys [client events]}]
   (when client 
-    (.close client)
-    (log/info "Disconnected from firehose"))
+    (.close client))
   (when events 
     (async/close! events)))
 
 (comment
-  ;; Example usage with timeout to avoid hanging
+  ;; Example usage
   (def conn (connect-firehose))
   
-  ;; Get one message with timeout
   (let [event (async/alt!!
                 (:events conn) ([v] v)
-                (async/timeout 5000) nil)]
-    (when event
-      (println "\nReceived event:" (pr-str event))))
+                (async/timeout 5000) :timeout)]
+    (println "\nReceived event:" 
+             {:type       (:type event)
+              :collection (:collection event)
+              :text      (get-in event [:record :text])}))
   
   (disconnect conn))

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -4,58 +4,46 @@
    [clojure.tools.logging :as log]
    [clj-cbor.core         :as cbor])
   (:import
-   [java.io  ByteArrayInputStream InputStream]
+   [java.io ByteArrayInputStream]
    [java.nio ByteBuffer]
    [java.net URI]
    [org.java_websocket.client WebSocketClient]
    [org.java_websocket.handshake ServerHandshake]))
 
-(defn buffer->bytes
-  "Convert a ByteBuffer to a byte array"
-  [^ByteBuffer buffer]
-  (let [bytes (byte-array (.remaining buffer))]
-    (.get buffer bytes)
-    bytes))
-
-(defn decode-varint
-  "Decode a variable-length integer from an input stream"
-  [^InputStream in]
-  (loop [shift  0
+(defn read-varint
+  "Read a variable-length integer from the input stream"
+  [^ByteArrayInputStream in]
+  (loop [shift 0
          result 0]
-    (let [byte (.read in)]
-      (if (neg? byte)
+    (let [b (.read in)]
+      (if (neg? b)
         (throw (ex-info "EOF while reading varint" {})))
-      (let [result (bit-or result (bit-shift-left (bit-and byte 0x7f) shift))]
-        (if (zero? (bit-and byte 0x80))
+      (let [val    (bit-and b 0x7F)
+            result (bit-or result (bit-shift-left val shift))]
+        (if (zero? (bit-and b 0x80))
           result
           (recur (+ shift 7) result))))))
 
 (defn decode-frame
-  "Decode a single CBOR frame from binary data"
-  [data codec]
-  (try
-    (let [bytes (if (instance? ByteBuffer data)
-                  (buffer->bytes data)
-                  data)]
+  "Decode a single frame from binary data"
+  [^ByteBuffer buffer]
+  (try 
+    (let [bytes (byte-array (.remaining buffer))]
+      (.get buffer bytes)
       (with-open [in (ByteArrayInputStream. bytes)]
-        (let [length    (decode-varint in)
-              remaining (.available in)]
-          (log/debug "Frame length:" length "remaining:" remaining)
-          (when (>= remaining length)
-            (let [buffer (byte-array length)
-                  bytes-read (.read in buffer 0 length)]
-              (when (= bytes-read length)
-                (with-open [frame-stream (ByteArrayInputStream. buffer)]
-                  (let [decoded (cbor/decode codec frame-stream)]
-                    (log/debug "Decoded frame type:" (type decoded))
-                    decoded))))))))
+        (let [frame-len   (read-varint in)
+              frame-bytes (byte-array frame-len)]
+          (.read in frame-bytes 0 frame-len)
+          (let [decoded (cbor/decode frame-bytes)]
+            {:header {:t  (get decoded "t")}
+                     :op (get decoded "op")
+             :body   decoded}))))
     (catch Exception e
-      (log/error e "Error decoding frame")
+      (log/error "Frame decode error:" (.getMessage e))
       nil)))
 
 (defn create-websocket-client
-  "Create a WebSocket client for the ATProto firehose"
-  [{:keys [uri output-ch codec]}]
+  [{:keys [uri output-ch]}]
   (proxy [WebSocketClient] [(URI. uri)]
     (onOpen [^ServerHandshake handshake]
       (log/info "Connected to firehose"))
@@ -63,56 +51,46 @@
     (onClose [code reason remote]
       (log/info "Disconnected from firehose:" reason))
     
-    (onMessage [data]
-      (when-let [decoded (decode-frame data codec)]
-        (log/debug "Received message of type:" (type decoded))
-        (async/>!! output-ch decoded)))
+    (onMessage [^ByteBuffer buffer]
+      (when-let [frame (decode-frame buffer)]
+        (async/>!! output-ch frame)))
     
     (onError [^Exception ex]
-      (log/error ex "WebSocket error"))))
+      (log/error "WebSocket error:" (.getMessage ex)))))
 
 (defn connect-firehose
-  "Connect to ATProto firehose and return a channel of decoded events.
-   
-   Options:
-   - :buffer-size - Size of the async buffer (default 1024)
-   - :service     - Service URL (default wss://bsky.network)
-   - :codec       - CBOR codec (default cbor/default-codec)"
-  [& {:keys [buffer-size service codec]
+  "Connect to ATProto firehose and return a channel of events"
+  [& {:keys [buffer-size service]
       :or   {buffer-size 1024
-             service     "wss://bsky.network"
-             codec       cbor/default-codec}}]
-  
+             service     "wss://bsky.network"}}]
   (let [output-ch (async/chan buffer-size)
         uri       (str service "/xrpc/com.atproto.sync.subscribeRepos")
         client    (create-websocket-client
                    {:uri       uri
-                    :output-ch output-ch
-                    :codec     codec})]
+                    :output-ch output-ch})]
     
-    (log/info "Connecting to firehose at" uri)
     (.connect client)
     
     {:client client
      :events output-ch}))
 
-(defn disconnect
-  "Cleanly disconnect firehose client"
+(defn disconnect 
   [{:keys [client events]}]
-  (when client
-    (.close client))
-  (when events
+  (when client 
+    (.close client)
+    (log/info "Disconnected from firehose"))
+  (when events 
     (async/close! events)))
 
 (comment
-  ;; Test connection
+  ;; Example usage with timeout to avoid hanging
   (def conn (connect-firehose))
   
-  ;; Print raw event type and structure
-  (let [event (async/<!! (:events conn))]
-    (println "Event type:" (type event))
-    (println "Event str:" (str event))
-    (println "Event pr-str:" (pr-str event)))
+  ;; Get one message with timeout
+  (let [event (async/alt!!
+                (:events conn) ([v] v)
+                (async/timeout 5000) nil)]
+    (when event
+      (println "\nReceived event:" (pr-str event))))
   
-  ;; Cleanup
   (disconnect conn))

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -8,7 +8,11 @@
    [org.java_websocket.client WebSocketClient]))
 
 (def parse-fn 
-  (json/parse-json-fn {:key-fn keyword}))
+  (json/parse-json-fn 
+   {:key-fn   keyword
+    :profile  :mutable ; Use mutable datastructures for better performance
+    :async?   false    ; Disable async for small messages
+    :bufsize  8192}))  ; Smaller buffer size for small messages}))
 
 (defn parse-message
   "Parse a message into a structured format"

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -89,5 +89,4 @@
   
   (disconnect conn)
   
-  
   ,)

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -8,7 +8,6 @@
    [org.java_websocket.client WebSocketClient]))
 
 (defn parse-firehose-message
-  "Parse a firehose message into a structured format"
   [message]
   (try
     (let [data (json/read-str message :key-fn keyword)]
@@ -34,10 +33,10 @@
   (doto 
     (proxy [WebSocketClient] [(URI. (str uri "?wantedCollections=app.bsky.feed.post"))]
       (onOpen [_]
-        (log/info "Connected to jetstream"))
+        (log/info "Connected to firehose"))
       
       (onClose [code reason remote]
-        (log/info "Disconnected from jetstream:" reason))
+        (log/info "Disconnected from firehose:" reason))
       
       (onMessage [message]
         (when-let [parsed (parse-firehose-message message)]
@@ -48,7 +47,7 @@
     (.setConnectionLostTimeout 60)))
 
 (defn connect-firehose
-  "Connect to ATProto firehose and return a channel of events"
+  "Returns a channel of events"
   [& {:keys [buffer-size service]
       :or   {buffer-size 1024
              service     "wss://jetstream2.us-east.bsky.network"}}]
@@ -69,7 +68,7 @@
     (async/close! events)))
 
 (comment
-  ;; Example usage
+
   (def conn (connect-firehose))
   
   (let [event (async/alt!!
@@ -80,4 +79,7 @@
               :collection (:collection event)
               :text      (get-in event [:record :text])}))
   
-  (disconnect conn))
+  (disconnect conn)
+  
+  
+  ,)

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -15,10 +15,9 @@
     :bufsize  8192}))  ; Smaller buffer size for small messages}))
 
 (defn parse-message
-  "Parse a message into a structured format"
-  [message]
+  [msg]
   (try
-    (let [data (parse-fn message)]
+    (let [data (parse-fn msg)]
       (case (:kind data)
         "commit" 
         {:type       :commit

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -1,12 +1,12 @@
 (ns net.gosha.atproto.firehose
   (:require
-   [clojure.core.async      :as async]
-   [clojure.tools.logging   :as log]
-   [clj-cbor.core           :as cbor])
+   [clojure.core.async    :as async]
+   [clojure.tools.logging :as log]
+   [clj-cbor.core         :as cbor])
   (:import
-   [java.io                 ByteArrayInputStream InputStream]
-   [java.nio                ByteBuffer]
-   [java.net                URI]
+   [java.io  ByteArrayInputStream InputStream]
+   [java.nio ByteBuffer]
+   [java.net URI]
    [org.java_websocket.client WebSocketClient]
    [org.java_websocket.handshake ServerHandshake]))
 
@@ -23,7 +23,7 @@
   (loop [shift  0
          result 0]
     (let [byte (.read in)]
-      (if (< byte 0)
+      (if (neg? byte)
         (throw (ex-info "EOF while reading varint" {})))
       (let [result (bit-or result (bit-shift-left (bit-and byte 0x7f) shift))]
         (if (zero? (bit-and byte 0x80))

--- a/src/net/gosha/atproto/firehose.clj
+++ b/src/net/gosha/atproto/firehose.clj
@@ -1,0 +1,113 @@
+(ns net.gosha.atproto.firehose
+  (:require
+   [clojure.core.async    :as async]
+   [clojure.tools.logging :as log]
+   [clj-cbor.core         :as cbor])
+  (:import
+   [java.io  ByteArrayInputStream InputStream]
+   [java.nio ByteBuffer]
+   [java.net URI]
+   [org.java_websocket.client WebSocketClient]
+   [org.java_websocket.handshake ServerHandshake]))
+
+(defn buffer->bytes
+  "Convert a ByteBuffer to a byte array"
+  [^ByteBuffer buffer]
+  (let [bytes (byte-array (.remaining buffer))]
+    (.get buffer bytes)
+    bytes))
+
+(defn decode-varint
+  "Decode a variable-length integer from an input stream"
+  [^InputStream in]
+  (loop [shift  0
+         result 0]
+    (let [byte (.read in)]
+      (if (< byte 0)
+        (throw (ex-info "EOF while reading varint" {})))
+      (let [result (bit-or result (bit-shift-left (bit-and byte 0x7f) shift))]
+        (if (zero? (bit-and byte 0x80))
+          result
+          (recur (+ shift 7) result))))))
+
+(defn decode-frame
+  "Decode a single CBOR frame from binary data"
+  [data codec]
+  (try
+    (let [bytes (if (instance? ByteBuffer data)
+                  (buffer->bytes data)
+                  data)]
+      (with-open [in (ByteArrayInputStream. bytes)]
+        (let [length    (decode-varint in)
+              remaining (.available in)]
+          (log/debug "Frame length:" length "remaining:" remaining)
+          (when (>= remaining length)
+            (let [buffer (byte-array length)
+                  bytes-read (.read in buffer 0 length)]
+              (when (= bytes-read length)
+                (with-open [frame-stream (ByteArrayInputStream. buffer)]
+                  (cbor/decode codec frame-stream))))))))
+    (catch Exception e
+      (log/error e "Error decoding frame")
+      nil)))
+
+(defn create-websocket-client
+  "Create a WebSocket client for the ATProto firehose"
+  [{:keys [uri output-ch codec]}]
+  (proxy [WebSocketClient] [(URI. uri)]
+    (onOpen [^ServerHandshake handshake]
+      (log/info "Connected to firehose"))
+    
+    (onClose [code reason remote]
+      (log/info "Disconnected from firehose:" reason))
+    
+    (onMessage [data]
+      (when-let [decoded (decode-frame data codec)]
+        (async/>!! output-ch decoded)))
+    
+    (onError [^Exception ex]
+      (log/error ex "WebSocket error"))))
+
+(defn connect-firehose
+  "Connect to ATProto firehose and return a channel of decoded events.
+   
+   Options:
+   - :buffer-size - Size of the async buffer (default 1024)
+   - :service     - Service URL (default wss://bsky.network)
+   - :codec       - CBOR codec (default cbor/default-codec)"
+  [& {:keys [buffer-size service codec]
+      :or   {buffer-size 1024
+             service     "wss://bsky.network"
+             codec       cbor/default-codec}}]
+  
+  (let [output-ch (async/chan buffer-size)
+        uri       (str service "/xrpc/com.atproto.sync.subscribeRepos")
+        client    (create-websocket-client
+                   {:uri       uri
+                    :output-ch output-ch
+                    :codec     codec})]
+    
+    (log/info "Connecting to firehose at" uri)
+    (.connect client)
+    
+    {:client client
+     :events output-ch}))
+
+(defn disconnect
+  "Cleanly disconnect firehose client"
+  [{:keys [client events]}]
+  (when client
+    (.close client))
+  (when events
+    (async/close! events)))
+
+(comment
+  ;; Test connection
+  (def conn (connect-firehose))
+  
+  ;; Monitor some events
+  (dotimes [_ 5]
+    (println (async/<!! (:events conn))))
+  
+  ;; Cleanup
+  (disconnect conn))

--- a/src/net/gosha/atproto/firehose_analysis.clj
+++ b/src/net/gosha/atproto/firehose_analysis.clj
@@ -1,0 +1,100 @@
+(ns net.gosha.atproto.firehose-analysis
+  (:require
+   [clojure.core.async      :as async]
+   [clojure.tools.logging   :as log]
+   [net.gosha.atproto.firehose :as firehose])
+  (:import
+   [java.time Instant Duration]))
+
+(defn create-window [start duration]
+  {:start-time      start
+   :end-time        (.plus start duration)
+   :message-count   0
+   :total-bytes     0
+   :types           {}})
+
+(defn create-analysis-state
+  [window-duration-seconds]
+  (let [now      (Instant/now)
+        duration (Duration/ofSeconds window-duration-seconds)]
+    {:start-time      now
+     :processed-count 0
+     :current-window  (create-window now duration)
+     :windows         []
+     :window-duration duration}))
+
+(defn update-window
+  "Update window stats with a new message"
+  [window message]
+  (let [msg-size (count (str message))]
+    (-> window
+        (update :message-count inc)
+        (update :total-bytes + msg-size)
+        (update-in [:types (:type message)] (fnil inc 0)))))
+
+(defn rotate-window!
+  "Check if current window should be rotated and create new window if needed"
+  [{:keys [current-window window-duration] :as state}]
+  (let [now (Instant/now)]
+    (if (.isAfter now (:end-time current-window))
+      (let [new-window (create-window now window-duration)]
+        (-> state
+            (update :windows conj current-window)
+            (assoc :current-window new-window)))
+      state)))
+
+(defn process-message!
+  "Process a single message and update analysis state"
+  [state message]
+  (-> state
+      rotate-window!
+      (update :processed-count inc)
+      (update :current-window update-window message)))
+
+(defn start-analysis
+  "Start analyzing messages from a firehose connection"
+  [conn & {:keys [window-duration-seconds]
+           :or   {window-duration-seconds 60}}]
+  (let [analysis-ch (async/chan 1024)
+        state       (atom (create-analysis-state window-duration-seconds))
+        mult        (async/mult (:events conn))]
+    
+    (async/tap mult analysis-ch)
+    
+    (async/go-loop []
+      (when-let [msg (async/<! analysis-ch)]
+        (swap! state process-message! msg)
+        (recur)))
+    
+    {:state       state
+     :analysis-ch analysis-ch}))
+
+(defn get-summary
+  "Generate a summary of the current analysis state"
+  [{:keys [start-time processed-count windows current-window]}]
+  (let [duration       (Duration/between start-time (Instant/now))
+        total-windows  (conj windows current-window)]
+    {:runtime-seconds  (.getSeconds duration)
+     :total-messages   processed-count
+     :messages-per-sec (float (/ processed-count 
+                                (max 1 (.getSeconds duration))))
+     :windows-summary  (->> total-windows
+                           (map #(select-keys % [:message-count :types]))
+                           (take-last 5))}))
+
+(defn stop-analysis
+  [{:keys [analysis-ch]}]
+  (async/close! analysis-ch))
+
+(comment
+  ;; Example usage
+  (def conn (firehose/connect-firehose))
+  (def analysis (start-analysis conn :window-duration-seconds 30))
+  
+  ;; Get current stats after running for a while
+  (get-summary @(:state analysis))
+  
+  ;; Cleanup
+  (stop-analysis analysis)
+  (firehose/disconnect conn)
+  ,)


### PR DESCRIPTION
## Overview
Creates two new namespaces - `firehose` and `firehose-analysis` that create a websocket client to connect to the atproto firehose (currently uses Bluesky's jetstream as source) and give the ability to analyze the incoming data.

## Features
- Websocket connection management with automatic reconnect
- Real-time analysis of firehose data including:
  - Message counts and rates
  - Message size statistics (raw bytes and content length)
  - Type distribution tracking
  - Time-windowed analysis
- Sample collection for offline analysis
- Uses `charred` for efficient JSON handling

## Example Usage
```clojure
;; Connect and analyze
(def conn (net.gosha.atproto.firehose/connect-firehose))
(def analysis (net.gosha.atproto.firehose-analysis/start-analysis conn))

;; Get current statistics
(net.gosha.atproto.firehose-analysis/get-summary @(:state analysis))

;; Collect samples
(net.gosha.atproto.firehose-analysis/collect-samples conn 10 
  :filename "samples/my-samples.json")

;; Cleanup
(net.gosha.atproto.firehose-analysis/stop-analysis analysis)
(net.gosha.atproto.firehose/disconnect conn)