### PR TITLE
Setting up Martian as a http client wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Work very much in progress
 
-### Progress
+## Progress
 
 | Feature      | Status |
 |--------------|--------|
@@ -24,12 +24,40 @@ Work very much in progress
 | plc          | 🔴    |
 | oauth server | 🔴    |
 
-### References
+## Usage
+
+### http client
+
+The client is using [Martian](https://github.com/oliyh/martian/) under the hood to handle the HTTP endpoints [published](https://github.com/bluesky-social/bsky-docs/tree/main/atproto-openapi-types) by the Bsky team in OpenAPI format
+
+```clojure
+(require '[net.gosha.atproto.core :as atproto]
+         '[net.gosha.atproto.client :as atproto-client])
+
+(atproto/init {:baase-url "https://bsky.social"
+               :username "someuser.bsky.social"
+               :app-password "some-app-password"})
+
+;; This will exchange the app password for a JWT token that can be used to query
+;; endpoints that require authentication.
+(atproto-client/authenticate!)
+
+;; Bluesky endpoints and their query params can be found here:
+;; https://docs.bsky.app/docs/category/http-reference
+(let [resp (atproto-client/call :app.bsky.actor.get-profile {:actor "gosha.net"})]
+  (select-keys (:body @resp) [:handle :displayName :createdAt :followersCount]))
+;; => {:handle "gosha.net",
+;; :displayName "Gosha ⚡",
+;; :createdAt "2023-05-08T19:08:05.781Z",
+;; :followersCount 617}
+```
+
+## References
 
 - [Existing SDKs](https://atproto.com/sdks)
 - [What goes in to a Bluesky or atproto SDK?](https://github.com/bluesky-social/atproto/discussions/2415)
 - [atproto Interop Test Files](https://github.com/bluesky-social/atproto-interop-tests)
 
-### Contribute
+## Contribute
 
 Help is very much welcomed! Please reach out on 🦋 [@gosha.net](https://bsky.app/profile/gosha.net)!

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,6 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/data.json {:mvn/version "2.5.0"}
         http-kit/http-kit {:mvn/version "2.8.0"}
-        metosin/reitit {:mvn/version "0.7.2"}}}
+        metosin/reitit {:mvn/version "0.7.2"}
+        com.github.oliyh/martian {:mvn/version "0.1.30"}
+        com.github.oliyh/martian-httpkit {:mvn/version "0.1.30"}}}

--- a/src/net/gosha/atproto/client.clj
+++ b/src/net/gosha/atproto/client.clj
@@ -9,9 +9,16 @@
 
 (def openapi-url "https://raw.githubusercontent.com/bluesky-social/bsky-docs/refs/heads/main/atproto-openapi-types/spec/api.json")
 
+(defn add-authentication-header [token]
+  {:name ::add-authentication-header
+   :enter (fn [ctx]
+            (assoc-in ctx [:request :headers "Authorization"] (str "Bearer " token)))})
+
 (def api (martian-http/bootstrap-openapi
            openapi-url
-           {:server-url (:base-url @core/config)}))
+           {:server-url (:base-url @core/config)
+            :interceptors (concat [(add-authentication-header (:auth-token @core/config))]
+                                  martian-http/default-interceptors)}))
 
 (defn request
   "Make an HTTP request to the atproto API.

--- a/src/net/gosha/atproto/core.clj
+++ b/src/net/gosha/atproto/core.clj
@@ -1,5 +1,6 @@
 (ns net.gosha.atproto.core
-  (:require [clojure.spec.alpha :as s]))
+  (:require
+   [clojure.spec.alpha :as s]))
 
 ;; Spec for SDK configuration
 (s/def ::base-url string?)
@@ -32,7 +33,6 @@
   ; Exchange app password for auth token
   (net.gosha.atproto.client/authenticate!)
   ; Make API requests
-  (net.gosha.atproto.client/get-req "/xrpc/com.atproto.server.getSession")
+  @(net.gosha.atproto.client/call :com.atproto.server.get-session))
   ; ???
   ; Profit
-  )


### PR DESCRIPTION
The intention here is to setup [Martian](https://github.com/oliyh/martian/) to handle HTTP requests to the API. 

We are using the OpenAPI format specs published by the Bluesky team from [here](https://raw.githubusercontent.com/bluesky-social/bsky-docs/refs/heads/main/atproto-openapi-types/spec/api.json) to initialise Martian, along with the `:base-url` provided when calling `core/init`.

## TODO
- [x] Automatically set auth headers when authenticated
- [x] Convenience functions
- [x] Update docs