### PR TITLE
Add support for core.async return values

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "examples"]
+{:paths ["src" "resources" "examples"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.clojure/core.async {:mvn/version "1.6.681"}

--- a/src/net/gosha/atproto/client.clj
+++ b/src/net/gosha/atproto/client.clj
@@ -23,7 +23,7 @@
 (defn- build-config
   "Build a configuration map based on defaults, env vars and provided values"
   [& {:as user-config}]
-  (-> {:openapi-spec "./resources/atproto-xrpc-openapi.2024-12-18.json"}
+  (-> {:openapi-spec "atproto-xrpc-openapi.2024-12-18.json"}
     (into (map (fn [[cfg-key env-var]]
                  (when-let [val (System/getenv env-var)]
                    {cfg-key val}))

--- a/src/net/gosha/atproto/client.clj
+++ b/src/net/gosha/atproto/client.clj
@@ -93,6 +93,5 @@
   - `session` The API session returned by `init`.
   - `endpoint` API endpoint for the format :com.atproto.server.get-session
   - `params` Map of params to pass to the endpoint"
-  ([session endpoint] (call session endpoint {}))
-  ([session endpoint opts]
-   (martian/response-for session endpoint opts)))
+  [session endpoint & {:as opts}]
+  (martian/response-for session endpoint opts))


### PR DESCRIPTION
- Update `call` signature to allow opts as destructured map
- core.async support
- load openapi spec from classpath (less fragile when library is used in a jar, etc)