### PR TITLE
Implements multi-user accounts and Refresh Expired Auth Tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 *.iml
 .clj-kondo
+.portal
 .lsp
 *.log
 tmp/
@@ -23,3 +24,4 @@ pom.xml.asc
 
 resources/dev-config.edn
 src/net/gosha/atproto/scratch.clj
+auth.edn

--- a/src/net/gosha/atproto/accounts.clj
+++ b/src/net/gosha/atproto/accounts.clj
@@ -1,0 +1,237 @@
+(ns net.gosha.atproto.accounts
+  (:require [clojure.spec.alpha    :as s]
+            [clojure.tools.logging :as log]
+            [martian.core          :as martian]
+            [martian.httpkit       :as martian-http]
+            [net.gosha.atproto.jwt :as jwt]
+            [net.gosha.atproto.specs.core :as type]))
+
+
+
+(defonce accounts (atom {:default-account nil
+                         :refresh-futures {}}))
+
+
+(declare schedule-token-refresh!)
+
+(defn create-session-config!
+  "Create a new session and config for an account. Stores them in
+   -> accounts.handle.session
+   -> accounts.handle.config
+   Returns the session object on success:
+   https://docs.bsky.app/docs/api/com-atproto-server-create-session
+
+   Optional arguments:
+   :default - if true, sets this account as the default account"
+  [handle & {:keys [default]}]
+  (let [handle (keyword handle)
+        auth   (-> "./auth.edn" slurp read-string handle)
+        config (merge
+                {:openapi-spec "atproto-xrpc-openapi.2024-12-18.json"}
+                auth)
+        _      (when-not (s/valid? ::type/auth-config config)
+                 (throw (ex-info "Invalid Auth Configuration"
+                                 {:errors (s/explain-str ::type/auth-config auth)})))
+        m-spec (martian-http/bootstrap-openapi
+                (:openapi-spec config)
+                {:server-url (:base-url config)})
+        response @(martian/response-for
+                   m-spec
+                   :com.atproto.server.create-session
+                   {:identifier (:username config)
+                    :password   (:account-password config)})]
+    (if-let [error (-> response :body :error)]
+      (throw (ex-info "Failed to create session"
+                      {:handle handle
+                       :error error}))
+      (let [session (:body response)]
+        ;; adds :config without password to handle's account
+        (swap! accounts assoc-in [handle :config]
+               {:base-url     (:base-url config)
+                :openapi-spec (:openapi-spec config)})
+        ;; adds ATProto :session to handle's account
+        (swap! accounts assoc-in [handle :session] session)
+        ;; sets default if none set yet, or :default true
+        (when (or default (nil? (:default-account @accounts)))
+          (swap! accounts assoc :default-account handle))
+        ;; automatically schedule token refresh
+        (schedule-token-refresh! handle)
+        session))))
+
+
+(defn- add-authentication-header [token]
+  {:name ::add-authentication-header
+   :enter (fn [ctx]
+            (assoc-in ctx [:request :headers "Authorization"]
+                      (str "Bearer " token)))})
+
+
+(defn authenticate
+  "Returns martian-spec with authentication headers"
+  [handle]
+  (let [handle (keyword handle)
+        config (-> @accounts handle :config)
+        token  (-> @accounts handle :session :accessJwt)]
+    (when-not token
+      (throw (ex-info "Account token not present. Make sure to login first (create-session)"
+                      {:handle handle})))
+    (martian-http/bootstrap-openapi (:openapi-spec config)
+                                    {:server-url (:base-url config)
+                                     :interceptors (cons (add-authentication-header token)
+                                                         martian-http/default-interceptors)})))
+
+
+(defn create-spec!
+  "Store an authenticated martian-spec in accounts.handle.m-spec"
+  [handle]
+  (let [handle (keyword handle)
+        m-spec (authenticate handle)]
+    (swap! accounts assoc-in [handle :m-spec] m-spec)))
+
+
+(defn set-default-account!
+  "Set the default account handle"
+  [handle]
+  (let [handle (keyword handle)]
+    (if-not (handle @accounts)
+      (throw (ex-info "Account does not Exist!" {:account handle}))
+      (do
+        (swap! accounts assoc :default-account handle)
+        handle))))
+
+
+(defn login!
+  "Reads config from auth file for given handle
+   Writes to accounts.handle :m-spec :session :config"
+  [handle & {:keys [default]}]
+  (create-session-config! handle)
+  (create-spec! handle)
+  (when default
+    (set-default-account! handle)))
+
+
+(defn refresh-session!
+  "Refresh an expired session token and return updated session.
+   Uses the refreshJwt token from the account's session to request a new accessJwt."
+  [handle]
+  (let [handle        (keyword handle)
+        refresh-token (-> @accounts handle :session :refreshJwt)
+        config        (-> @accounts handle :config)
+        m-spec  (martian-http/bootstrap-openapi
+                 (:openapi-spec config)
+                 {:server-url (:base-url config)
+                  :interceptors (cons (add-authentication-header refresh-token)
+                                      martian-http/default-interceptors)})
+        response @(martian/response-for
+                   m-spec
+                   :com.atproto.server.refresh-session
+                   {})]
+    (if-let [error (-> response :body :error)]
+      (throw (ex-info "Failed to refresh token: "
+                      {:account handle
+                       :error   error
+                       :message (-> response :body :message)}))
+      (let [new-session (:body response)]
+        (swap! accounts assoc-in [handle :session] new-session)
+        (create-spec! handle)
+        new-session))))
+
+
+(defn schedule-token-refresh!
+  "Schedule a token refresh before expiration.
+
+   Arguments:
+   - handle: The account handle to refresh
+   - seconds-before: Number of seconds before expiration to refresh (default: 60)
+
+   Returns a Timer that can be cancelled if needed."
+  ([handle]
+   (schedule-token-refresh! handle 60))
+  ([handle seconds-before]
+   (let [handle        (keyword handle)
+         session       (-> @accounts handle :session)
+         exp-timestamp (-> session :accessJwt jwt/parse-jwt :payload :exp)
+         exp-instant   (java.time.Instant/ofEpochSecond exp-timestamp)
+         now           (java.time.Instant/now)
+         refresh-at    (.minusSeconds exp-instant seconds-before)
+         delay-ms      (- (.toEpochMilli refresh-at) (.toEpochMilli now))
+         timer        (java.util.Timer. (str "refresh-" handle) true)]
+     (when (pos? delay-ms)
+       (.schedule timer
+                 (proxy [java.util.TimerTask] []
+                   (run []
+                     (try
+                       (refresh-session! handle)
+                       (catch Exception e
+                         (clojure.tools.logging/error
+                          e "Failed to refresh token for " handle))
+                       (finally
+                         (swap! accounts update :refresh-futures dissoc handle)
+                         (.cancel timer)))))
+                 delay-ms)
+       (swap! accounts assoc-in [:refresh-futures handle] timer)
+       timer))))
+
+
+(defn cancel-refresh!
+  "Cancel scheduled token refresh for an account if it exists."
+  [handle]
+  (when-let [timer (get-in @accounts [:refresh-futures (keyword handle)])]
+    (.cancel timer)
+    (swap! accounts update :refresh-futures dissoc (keyword handle))
+    true))
+
+
+(defn list-accounts "List all registered account handles" []
+  (let [account-keys (set (keys @accounts))
+        exclude-set  (set [:default-account :refresh-futures])
+        accounts     (into [] (clojure.set/difference account-keys exclude-set))]
+    accounts))
+
+
+(defn remove-account!
+  "Remove an account by handle; also cancels any pending refresh futures
+   Removing the default account, sets new default if other accounts exist."
+  [handle]
+  (swap! accounts dissoc handle)
+  (cancel-refresh! handle)
+  (when (= handle (:default-account @accounts))
+    (if-let [next-id (first (list-accounts))]
+      (swap! accounts assoc :default-account next-id)
+      (swap! accounts assoc :default-account nil))))
+
+
+
+(defn remove-all-accounts! []
+  (for [account (list-accounts)]
+    (remove-account! account)))
+
+
+
+
+
+
+(comment
+
+  (login! :zed.earth :default true)
+  (login! :zed.zaluka.xyz)
+
+  (-> @accounts :default-account)
+  (-> @accounts :refresh-futures)
+
+  (-> @accounts :zed.earth :m-spec)
+  (-> @accounts :zed.earth :session)
+
+  (list-accounts)
+  (remove-all-accounts!)
+
+  (-> @accounts :zed.zaluka.xyz :session
+      :accessJwt jwt/parse-jwt :payload :exp jwt/unix-to-date)
+  ;; "2025-01-12 05:26:51"
+
+  (-> @accounts :zed.earth :session
+      :accessJwt jwt/expired?)
+
+  (refresh-session! :zed.zaluka.xyz)
+
+  #_{})

--- a/src/net/gosha/atproto/client.clj
+++ b/src/net/gosha/atproto/client.clj
@@ -1,103 +1,47 @@
 (ns net.gosha.atproto.client
   (:require
-   [clojure.core.async :as a]
-   [clojure.spec.alpha :as s]
-   [clojure.tools.logging :as log]
-   [martian.core :as martian]
-   [martian.httpkit :as martian-http]))
-
-(s/def ::username string?)
-(s/def ::base-url string?)
-(s/def ::app-password string?)
-(s/def ::openapi-spec string?)
-(s/def ::config (s/keys :req-un [::base-url ::openapi-spec]
-                  :opt-un [::app-password ::username]))
-
-(def ^{:doc "map of config keys to env vars that can set them"}
-  env-keys
-  {:openapi-spec "ATPROTO_OPENAPI_SPEC"
-   :base-url "ATPROTO_BASE_URL"
-   :username "ATPROTO_USERNAME"
-   :app-password "ATPROTO_APP_PASSWORD"})
-
-(defn- build-config
-  "Build a configuration map based on defaults, env vars and provided values"
-  [& {:as user-config}]
-  (-> {:openapi-spec "atproto-xrpc-openapi.2024-12-18.json"}
-    (into (map (fn [[cfg-key env-var]]
-                 (when-let [val (System/getenv env-var)]
-                   {cfg-key val}))
-            env-keys))
-    (merge user-config)))
-
-(defn- add-authentication-header [token]
-  {:name ::add-authentication-header
-   :enter (fn [ctx]
-            (assoc-in ctx [:request :headers "Authorization"]
-              (str "Bearer " token)))})
-
-;; TODO: automatically refresh expired tokens
-(defn authenticate
-  "Given an api session, authenticate with the atproto API using an app password
-  and return an authenticated api session.
-
-  Note that the session will only work as long as the token is valid. If the
-  token expires, authenticate will need to be called again."
-  [session]
-  (let [{:keys [username app-password openapi-spec base-url]} (::config session)
-        response @(martian/response-for
-                    session
-                    :com.atproto.server.create-session
-                    {:identifier username :password app-password})
-        token (get-in response [:body :accessJwt])]
-    (when-not token
-      (if (:status response)
-        (throw (ex-info (format "Authorization failed (%s)" (:status response))
-                 {:response response}))
-        (throw (ex-info "Authorization failed (unknown error)"
-                 {:response response}))))
-    (martian-http/bootstrap-openapi openapi-spec
-      {:server-url base-url
-       :interceptors (cons (add-authentication-header token)
-                       martian-http/default-interceptors)})))
-
-(defn init
-  "Create and return a new api session. Valid configuration options are:
-
-  :username - (optional) Bluesky username.
-  :app-password - (optional) Bluesky appplication-specific password.
-  :base-url - Bluesky endpoint. Mandatory. Use 'https://public.api.bsky.app'
-              for unauthenticated access, 'https://bsky.social' for
-              authenticated, or a different endpoint if you know what you're
-              doing.
-  :openapi-spec - OpenAPI JSON specification. Defaults to the included spec.
-
-  All options can be specifed via an environment variable prefixed by `ATPROTO_`
-  (e.g. ATPROTO_BASE_URL)."
-  [& {:as options}]
-  (let [{:keys [openapi-spec
-                base-url
-                username
-                app-password] :as config} (build-config options)]
-    (when-not (s/valid? ::config config)
-      (throw (ex-info "Invalid configuration"
-               {:errors (s/explain-str ::config config)})))
-    (let [session (martian-http/bootstrap-openapi openapi-spec
-                    {:server-url base-url})
-          session (assoc session ::config config)]
-      (if username
-        (authenticate session)
-        session))))
+   [clojure.core.async         :as a]
+   [clojure.tools.logging      :as log]
+   [martian.core               :as martian]
+   [net.gosha.atproto.accounts :as accounts :refer
+    [accounts refresh-session!]]))
 
 (defn call
   "Make an HTTP request to the atproto API.
-
-  - `session` The API session returned by `init`.
   - `endpoint` API endpoint for the format :com.atproto.server.get-session
   - `params` Map of params to pass to the endpoint"
-  [session endpoint & {:as opts}]
-  (martian/response-for session endpoint opts))
+  ([endpoint params]
+   (if-let [default-user (:default-account @accounts)]
+     (call default-user endpoint params)
+     (throw (ex-info "No default account set" {}))))
+  ([handle endpoint params]
+   (let [handle (keyword handle)
+         spec   (-> @accounts handle :m-spec)
+         res   @(martian/response-for spec endpoint params)]
+     (if-let [error (-> res :body :error)]
+       (do
+         (log/warn "API error: " error
+                    "message: "  (-> res :body :message)
+                    "endpoint: " endpoint
+                    "account: "  handle)
+         (if (= error "ExpiredToken")
+           (do
+             (refresh-session! handle)
+             (call handle endpoint params))
+           res))
+       res))))
 
+
+(defn response-for
+  ([endpoint params]
+   (if-let [default-user (:default-account @accounts)]
+     (response-for default-user endpoint params)
+     (throw (ex-info "No default account set" {}))))
+  ([handle endpoint params]
+   (:body (call handle endpoint params))))
+
+
+#_
 (defn call-async
   "Like `call`, but returns a core.async channel instead of a IBlockingDeref.
 

--- a/src/net/gosha/atproto/json.clj
+++ b/src/net/gosha/atproto/json.clj
@@ -1,0 +1,7 @@
+(ns net.gosha.atproto.json
+  (:require [charred.api :refer [parse-json-fn]]))
+
+(def parse
+  (parse-json-fn
+   {:key-fn  keyword
+    :profile :immutable}))

--- a/src/net/gosha/atproto/jwt.clj
+++ b/src/net/gosha/atproto/jwt.clj
@@ -1,0 +1,30 @@
+(ns net.gosha.atproto.jwt
+  (:require
+   [net.gosha.atproto.json :as json]
+   [clojure.string :as str])
+  (:import
+   [java.util Base64]))
+
+
+(defn b64-decode [^String to-decode]
+  (String. (.decode (Base64/getDecoder) to-decode)))
+
+(defn parse-jwt [jwt]
+  (let [[header payload signature] (str/split jwt #"\.")]
+    {:header    (json/parse (b64-decode header))
+     :payload   (json/parse (b64-decode payload))
+     :signature signature}))
+
+(defn unix-to-date [timestamp]
+  (let [format (java.text.SimpleDateFormat. "yyyy-MM-dd HH:mm:ss")
+        date   (java.util.Date. (* 1000 timestamp))]
+    (.format format date)))
+
+(defn expired?
+  "Check if a JWT token has expired.
+   Returns true if the token's expiration timestamp is in the past."
+  [jwt]
+  (let [exp-timestamp (-> jwt parse-jwt :payload :exp)
+        exp-instant   (java.time.Instant/ofEpochSecond exp-timestamp)
+        now           (java.time.Instant/now)]
+    (.isBefore exp-instant now)))

--- a/src/net/gosha/atproto/specs/core.clj
+++ b/src/net/gosha/atproto/specs/core.clj
@@ -1,0 +1,57 @@
+(ns net.gosha.atproto.specs.core
+  (:require [clojure.spec.alpha :as s]
+            [martian.core]))
+
+;; common types
+(s/def ::base-url     string?)
+(s/def ::openapi-spec string?)
+
+;; auth and config spec types
+(s/def ::username         string?)
+(s/def ::account-password string?)
+(s/def ::auth-config (s/keys :req-un [::base-url         ::openapi-spec]
+                             :opt-un [::account-password ::username]))
+
+
+
+
+;; -------------------  Single Account Spec -------------------------------
+;; Account configuration
+(s/def ::account-config (s/keys :req-un [::base-url ::openapi-spec]))
+
+;; ATProto object returned from createSession
+(s/def ::session map?)
+
+;; Martian client spec
+(s/def ::m-spec (s/spec #(instance? martian.core.Martian %))) ;; Martian client instance
+
+;; Single account entry structure
+(s/def ::account (s/keys :req-un [::session
+                                  ::m-spec
+                                  ::account-config]))
+;; ------------------------------------------------------------------------
+
+
+
+;; -------------------  Accounts Spec -------------------------------------
+;; Timer for refresh futures
+(s/def ::refresh-timer   (s/spec #(instance? java.util.Timer %)))
+(s/def ::refresh-futures (s/map-of keyword? ::refresh-timer))
+
+;; account handle and default account types
+(s/def ::account-handle  keyword?)
+(s/def ::default-account ::account-handle)
+
+;; Main accounts atom structure
+(s/def ::accounts (s/keys :req-un [::default-account
+                                   ::refresh-futures]
+                          :opt-un [::account]))
+;; ------------------------------------------------------------------------
+
+
+
+;; TODO possibly structure specs in separate ns
+;; include all specs in specs/core.clj
+;; specs/core.clj
+;;      /accounts-spec.clj
+;;      /auth-spec.clj  .... etc.


### PR DESCRIPTION
This feature commit introduces some major changes.

1. **Account Management**:
   - Adds `accounts.clj`, which implements multiuser accounts in a global atom, `accounts`
   - clarifies the use of the abstraction `session`, which is the return object from ATProto `createSession` from the conflation with martian.core.Martian instance
   - an account is stored as a keyword of user handle in `accounts`,  and a map structure of `:session` `:m-spec` and a `:config` which holds base-url and openapi source string

   - pretty much all functions now take a simple handle as a parameter, from which the relevant information is retrieved or populated via the global `accounts` atom
2. **Refresh Expired Auth Tokens**:
   - Reason for needing to store ATProto Session, is to hold onto the :refreshJwt, which is distinct from the :accessJwt, to refresh session on expired :accessJwt tokens
   - stores all refresh token Timers in `accounts` atom `:refresh-futures` (should change name...), maybe `:refresh-timers`, yeah
3. **Auth**:
   - is currently handled by reading in `./auth.edn` in the project root directory and expects a structure like:
```clojure
{:handle1 {:username "handle1"
           :account-password __password1__
           :base-url "https://bsky.social"}
 :handle2 {:username "handle2"
           :account-password __password2__
           :base-url "https://custom-pds.xyz"}...}
```
   - auth is a bit of a WIP... happy for suggestions, recommendations on this
4. **Client changes**:
   - Since `accounts.clj` holds most of the logic for token-sessions, etc., `client` is now a refactored `call`
   - also added another functions `response-for` that returns the :body of `call`
   - if no handle is provided, it will use the `:default-account` in `accounts`
   - if accessJwt is expired, will automatically call refresh-session! and retry
5. **Other Changes**:
   - Moved the spec definitions to `.../atproto/specs/core.clj` - could be expanded upon in the future
   - adds `jwt.clj` for parsing session token, in order to know when to schedule refresh

Resolves: [https://github.com/goshatch/atproto-clojure/issues/6] [https://github.com/goshatch/atproto-clojure/pull/8]