### PR TITLE
Resolves #11: Adds pulling from the latest Bluesky OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pom.xml.asc
 
 resources/dev-config.edn
 src/net/gosha/atproto/scratch.clj
+/.portal/


### PR DESCRIPTION
Still maintains local backup as fall-back
Will use user supplied values (either in call or as env variables) first before trying to pull from online source.